### PR TITLE
custom name for cloud resources

### DIFF
--- a/tasks/cloud_vpn/provisioners/aws_igw/initiator/deprovision.yaml
+++ b/tasks/cloud_vpn/provisioners/aws_igw/initiator/deprovision.yaml
@@ -1,8 +1,8 @@
 ---
 - name: Delete initiator cloudformation IGW stack
   cloudformation:
-    aws_access_key: "{{ cloud_vpn_initiator_aws_access_key  }}"
-    aws_secret_key: "{{ cloud_vpn_initiator_aws_secret_key  }}"
+    aws_access_key: "{{ cloud_vpn_initiator_aws_access_key | default(omit) }}"
+    aws_secret_key: "{{ cloud_vpn_initiator_aws_secret_key | default(omit) }}"
     security_token: "{{ cloud_vpn_initiator_aws_security_token | default(omit) }}"
     region: "{{ cloud_vpn_initiator_aws_region }}"
     stack_name: "{{ cloud_vpn_name }}-initiator-igw-stack"

--- a/tasks/cloud_vpn/provisioners/aws_igw/initiator/get_facts.yaml
+++ b/tasks/cloud_vpn/provisioners/aws_igw/initiator/get_facts.yaml
@@ -2,8 +2,8 @@
 
 - name: Get initiator cloudformation IGW stack facts
   cloudformation_facts:
-    aws_access_key: "{{ cloud_vpn_initiator_aws_access_key  }}"
-    aws_secret_key: "{{ cloud_vpn_initiator_aws_secret_key  }}"
+    aws_access_key: "{{ cloud_vpn_initiator_aws_access_key | default(omit) }}"
+    aws_secret_key: "{{ cloud_vpn_initiator_aws_secret_key | default(omit) }}"
     security_token: "{{ cloud_vpn_initiator_aws_security_token | default(omit) }}"
     region: "{{ cloud_vpn_initiator_aws_region }}"
     stack_name: "{{ cloud_vpn_name }}-initiator-igw-stack"

--- a/tasks/cloud_vpn/provisioners/aws_igw/initiator/provision.yaml
+++ b/tasks/cloud_vpn/provisioners/aws_igw/initiator/provision.yaml
@@ -2,8 +2,8 @@
 
 - name: Create initiator cloudformation IGW stack
   cloudformation:
-    aws_access_key: "{{ cloud_vpn_initiator_aws_access_key  }}"
-    aws_secret_key: "{{ cloud_vpn_initiator_aws_secret_key  }}"
+    aws_access_key: "{{ cloud_vpn_initiator_aws_access_key | default(omit) }}"
+    aws_secret_key: "{{ cloud_vpn_initiator_aws_secret_key | default(omit) }}"
     security_token: "{{ cloud_vpn_initiator_aws_security_token | default(omit) }}"
     region: "{{ cloud_vpn_initiator_aws_region }}"
     stack_name: "{{ cloud_vpn_name }}-initiator-igw-stack"

--- a/tasks/cloud_vpn/provisioners/aws_igw/responder/deprovision.yaml
+++ b/tasks/cloud_vpn/provisioners/aws_igw/responder/deprovision.yaml
@@ -1,8 +1,9 @@
 ---
 - name: Delete responder cloudformation IGW stack
+  run_once: true
   cloudformation:
-    aws_access_key: "{{ cloud_vpn_responder_aws_access_key  }}"
-    aws_secret_key: "{{ cloud_vpn_responder_aws_secret_key  }}"
+    aws_access_key: "{{ cloud_vpn_responder_aws_access_key | default(omit) }}"
+    aws_secret_key: "{{ cloud_vpn_responder_aws_secret_key | default(omit) }}"
     security_token: "{{ cloud_vpn_responder_aws_security_token | default(omit) }}"
     region: "{{ cloud_vpn_responder_aws_region }}"
     stack_name: "{{ cloud_vpn_name }}-responder-igw-stack"

--- a/tasks/cloud_vpn/provisioners/aws_igw/responder/get_facts.yaml
+++ b/tasks/cloud_vpn/provisioners/aws_igw/responder/get_facts.yaml
@@ -2,8 +2,8 @@
 
 - name: Get responder cloudformation IGW stack facts
   cloudformation_facts:
-    aws_access_key: "{{ cloud_vpn_responder_aws_access_key  }}"
-    aws_secret_key: "{{ cloud_vpn_responder_aws_secret_key  }}"
+    aws_access_key: "{{ cloud_vpn_responder_aws_access_key | default(omit) }}"
+    aws_secret_key: "{{ cloud_vpn_responder_aws_secret_key | default(omit) }}"
     security_token: "{{ cloud_vpn_responder_aws_security_token | default(omit) }}"
     region: "{{ cloud_vpn_responder_aws_region }}"
     stack_name: "{{ cloud_vpn_name }}-responder-igw-stack"

--- a/tasks/cloud_vpn/provisioners/aws_igw/responder/provision.yaml
+++ b/tasks/cloud_vpn/provisioners/aws_igw/responder/provision.yaml
@@ -1,9 +1,10 @@
 ---
 
 - name: Create responder cloudformation IGW stack
+  run_once: true
   cloudformation:
-    aws_access_key: "{{ cloud_vpn_responder_aws_access_key  }}"
-    aws_secret_key: "{{ cloud_vpn_responder_aws_secret_key  }}"
+    aws_access_key: "{{ cloud_vpn_responder_aws_access_key | default(omit) }}"
+    aws_secret_key: "{{ cloud_vpn_responder_aws_secret_key | default(omit) }}"
     security_token: "{{ cloud_vpn_responder_aws_security_token | default(omit) }}"
     region: "{{ cloud_vpn_responder_aws_region }}"
     stack_name: "{{ cloud_vpn_name }}-responder-igw-stack"

--- a/tasks/cloud_vpn/provisioners/aws_instance/initiator/deprovision.yaml
+++ b/tasks/cloud_vpn/provisioners/aws_instance/initiator/deprovision.yaml
@@ -1,8 +1,8 @@
 ---
 - name: Delete initiator instance stack
   cloudformation:
-    aws_access_key: "{{ cloud_vpn_initiator_aws_access_key  }}"
-    aws_secret_key: "{{ cloud_vpn_initiator_aws_secret_key  }}"
+    aws_access_key: "{{ cloud_vpn_initiator_aws_access_key | default(omit) }}"
+    aws_secret_key: "{{ cloud_vpn_initiator_aws_secret_key | default(omit) }}"
     security_token: "{{ cloud_vpn_initiator_aws_security_token | default(omit) }}"
     region: "{{ cloud_vpn_initiator_aws_region }}"
     stack_name: "{{ cloud_vpn_name }}-initiator-instance-stack"

--- a/tasks/cloud_vpn/provisioners/aws_instance/initiator/get_facts.yaml
+++ b/tasks/cloud_vpn/provisioners/aws_instance/initiator/get_facts.yaml
@@ -2,8 +2,8 @@
 
 - name: Get initiator cloudformation instance stack facts
   cloudformation:
-    aws_access_key: "{{ cloud_vpn_initiator_aws_access_key  }}"
-    aws_secret_key: "{{ cloud_vpn_initiator_aws_secret_key  }}"
+    aws_access_key: "{{ cloud_vpn_initiator_aws_access_key | default(omit) }}"
+    aws_secret_key: "{{ cloud_vpn_initiator_aws_secret_key | default(omit) }}"
     security_token: "{{ cloud_vpn_initiator_aws_security_token | default(omit) }}"
     region: "{{ cloud_vpn_initiator_aws_region }}"
     stack_name: "{{ cloud_vpn_name }}-initiator-instance-stack"

--- a/tasks/cloud_vpn/provisioners/aws_instance/initiator/provision.yaml
+++ b/tasks/cloud_vpn/provisioners/aws_instance/initiator/provision.yaml
@@ -2,8 +2,8 @@
 
 - name: Create initiator cloudformation instance stack
   cloudformation:
-    aws_access_key: "{{ cloud_vpn_initiator_aws_access_key  }}"
-    aws_secret_key: "{{ cloud_vpn_initiator_aws_secret_key  }}"
+    aws_access_key: "{{ cloud_vpn_initiator_aws_access_key | default(omit) }}"
+    aws_secret_key: "{{ cloud_vpn_initiator_aws_secret_key | default(omit) }}"
     security_token: "{{ cloud_vpn_initiator_aws_security_token | default(omit) }}"
     region: "{{ cloud_vpn_initiator_aws_region }}"
     stack_name: "{{ cloud_vpn_name }}-initiator-instance-stack"
@@ -11,12 +11,12 @@
 
 - name: Get initiator instance facts
   ec2_instance_facts:
-    aws_access_key: "{{ cloud_vpn_initiator_aws_access_key }}"
-    aws_secret_key: "{{ cloud_vpn_initiator_aws_secret_key }}"
+    aws_access_key: "{{ cloud_vpn_initiator_aws_access_key | default(omit) }}"
+    aws_secret_key: "{{ cloud_vpn_initiator_aws_secret_key | default(omit) }}"
     security_token: "{{ cloud_vpn_initiator_aws_security_token | default(omit) }}"
     region: "{{ cloud_vpn_initiator_aws_region }}"
     filters:
-      tag:Name: "{{ cloud_vpn_name }}-initiator-instance"
+      tag:Name: "{{ cloud_vpn_initiator_instance_name }}"
       instance-state-name: running
   register: out
 

--- a/tasks/cloud_vpn/provisioners/aws_instance/responder/deprovision.yaml
+++ b/tasks/cloud_vpn/provisioners/aws_instance/responder/deprovision.yaml
@@ -1,8 +1,9 @@
 ---
 - name: Delete responder instance stack
+  run_once: true
   cloudformation:
-    aws_access_key: "{{ cloud_vpn_responder_aws_access_key  }}"
-    aws_secret_key: "{{ cloud_vpn_responder_aws_secret_key  }}"
+    aws_access_key: "{{ cloud_vpn_responder_aws_access_key | default(omit) }}"
+    aws_secret_key: "{{ cloud_vpn_responder_aws_secret_key | default(omit) }}"
     security_token: "{{ cloud_vpn_responder_aws_security_token | default(omit) }}"
     region: "{{ cloud_vpn_responder_aws_region }}"
     stack_name: "{{ cloud_vpn_name }}-responder-instance-stack"

--- a/tasks/cloud_vpn/provisioners/aws_instance/responder/get_facts.yaml
+++ b/tasks/cloud_vpn/provisioners/aws_instance/responder/get_facts.yaml
@@ -1,9 +1,10 @@
 ---
 
 - name: Get responder cloudformation instance stack facts
+  run_once: true
   cloudformation:
-    aws_access_key: "{{ cloud_vpn_responder_aws_access_key  }}"
-    aws_secret_key: "{{ cloud_vpn_responder_aws_secret_key  }}"
+    aws_access_key: "{{ cloud_vpn_responder_aws_access_key | default(omit) }}"
+    aws_secret_key: "{{ cloud_vpn_responder_aws_secret_key | default(omit) }}"
     security_token: "{{ cloud_vpn_responder_aws_security_token | default(omit) }}"
     region: "{{ cloud_vpn_responder_aws_region }}"
     stack_name: "{{ cloud_vpn_name }}-responder-instance-stack"

--- a/tasks/cloud_vpn/provisioners/aws_instance/responder/provision.yaml
+++ b/tasks/cloud_vpn/provisioners/aws_instance/responder/provision.yaml
@@ -1,9 +1,10 @@
 ---
 
-- name: Create responder cloudformation instance stack
+- name: Create responder cloudformation instance stack (once)
+  run_once: true
   cloudformation:
-    aws_access_key: "{{ cloud_vpn_responder_aws_access_key  }}"
-    aws_secret_key: "{{ cloud_vpn_responder_aws_secret_key  }}"
+    aws_access_key: "{{ cloud_vpn_responder_aws_access_key | default(omit) }}"
+    aws_secret_key: "{{ cloud_vpn_responder_aws_secret_key | default(omit) }}"
     security_token: "{{ cloud_vpn_responder_aws_security_token | default(omit) }}"
     region: "{{ cloud_vpn_responder_aws_region }}"
     stack_name: "{{ cloud_vpn_name }}-responder-instance-stack"
@@ -11,12 +12,12 @@
 
 - name: Get responder instance facts
   ec2_instance_facts:
-    aws_access_key: "{{ cloud_vpn_responder_aws_access_key }}"
-    aws_secret_key: "{{ cloud_vpn_responder_aws_secret_key }}"
+    aws_access_key: "{{ cloud_vpn_responder_aws_access_key | default(omit) }}"
+    aws_secret_key: "{{ cloud_vpn_responder_aws_secret_key | default(omit) }}"
     security_token: "{{ cloud_vpn_responder_aws_security_token | default(omit) }}"
     region: "{{ cloud_vpn_responder_aws_region }}"
     filters:
-      tag:Name: "{{ cloud_vpn_name }}-responder-instance"
+      tag:Name: "{{ cloud_vpn_responder_instance_name }}"
       instance-state-name: running
   register: out
 

--- a/tasks/cloud_vpn/provisioners/aws_keypair/initiator/deprovision.yaml
+++ b/tasks/cloud_vpn/provisioners/aws_keypair/initiator/deprovision.yaml
@@ -2,8 +2,8 @@
 
 - name: Delete initiator keypair
   ec2_key:
-    aws_access_key: "{{ cloud_vpn_initiator_aws_access_key  }}"
-    aws_secret_key: "{{ cloud_vpn_initiator_aws_secret_key  }}"
+    aws_access_key: "{{ cloud_vpn_initiator_aws_access_key | default(omit) }}"
+    aws_secret_key: "{{ cloud_vpn_initiator_aws_secret_key | default(omit) }}"
     security_token: "{{ cloud_vpn_initiator_aws_security_token | default(omit) }}"
     region: "{{ cloud_vpn_initiator_aws_region }}"
     name: "{{ cloud_vpn_initiator_key_name }}"

--- a/tasks/cloud_vpn/provisioners/aws_keypair/initiator/provision.yaml
+++ b/tasks/cloud_vpn/provisioners/aws_keypair/initiator/provision.yaml
@@ -2,8 +2,8 @@
 
 - name: Create initiator keypair
   ec2_key:
-    aws_access_key: "{{ cloud_vpn_initiator_aws_access_key  }}"
-    aws_secret_key: "{{ cloud_vpn_initiator_aws_secret_key  }}"
+    aws_access_key: "{{ cloud_vpn_initiator_aws_access_key | default(omit) }}"
+    aws_secret_key: "{{ cloud_vpn_initiator_aws_secret_key | default(omit) }}"
     security_token: "{{ cloud_vpn_initiator_aws_security_token | default(omit) }}"
     region: "{{ cloud_vpn_initiator_aws_region }}"
     name: "{{ cloud_vpn_initiator_key_name }}"

--- a/tasks/cloud_vpn/provisioners/aws_keypair/responder/deprovision.yaml
+++ b/tasks/cloud_vpn/provisioners/aws_keypair/responder/deprovision.yaml
@@ -1,9 +1,10 @@
 ---
 
 - name: Delete responder keypair
+  run_once: true
   ec2_key:
-    aws_access_key: "{{ cloud_vpn_responder_aws_access_key  }}"
-    aws_secret_key: "{{ cloud_vpn_responder_aws_secret_key  }}"
+    aws_access_key: "{{ cloud_vpn_responder_aws_access_key | default(omit) }}"
+    aws_secret_key: "{{ cloud_vpn_responder_aws_secret_key | default(omit) }}"
     security_token: "{{ cloud_vpn_responder_aws_security_token | default(omit) }}"
     region: "{{ cloud_vpn_responder_aws_region }}"
     name: "{{ cloud_vpn_responder_key_name }}"

--- a/tasks/cloud_vpn/provisioners/aws_keypair/responder/provision.yaml
+++ b/tasks/cloud_vpn/provisioners/aws_keypair/responder/provision.yaml
@@ -1,9 +1,10 @@
 ---
 
 - name: Create responder keypair
+  run_once: true
   ec2_key:
-    aws_access_key: "{{ cloud_vpn_responder_aws_access_key  }}"
-    aws_secret_key: "{{ cloud_vpn_responder_aws_secret_key  }}"
+    aws_access_key: "{{ cloud_vpn_responder_aws_access_key | default(omit) }}"
+    aws_secret_key: "{{ cloud_vpn_responder_aws_secret_key | default(omit) }}"
     security_token: "{{ cloud_vpn_responder_aws_security_token | default(omit) }}"
     region: "{{ cloud_vpn_responder_aws_region }}"
     name: "{{ cloud_vpn_responder_key_name }}"

--- a/tasks/cloud_vpn/provisioners/aws_vpc/initiator/deprovision.yaml
+++ b/tasks/cloud_vpn/provisioners/aws_vpc/initiator/deprovision.yaml
@@ -1,8 +1,8 @@
 ---
 - name: Delete initiator cloudformation VPC stack
   cloudformation:
-    aws_access_key: "{{ cloud_vpn_initiator_aws_access_key  }}"
-    aws_secret_key: "{{ cloud_vpn_initiator_aws_secret_key  }}"
+    aws_access_key: "{{ cloud_vpn_initiator_aws_access_key | default(omit) }}"
+    aws_secret_key: "{{ cloud_vpn_initiator_aws_secret_key | default(omit) }}"
     security_token: "{{ cloud_vpn_initiator_aws_security_token | default(omit) }}"
     region: "{{ cloud_vpn_initiator_aws_region }}"
     stack_name: "{{ cloud_vpn_name }}-initiator-vpc-stack"

--- a/tasks/cloud_vpn/provisioners/aws_vpc/initiator/get_facts.yaml
+++ b/tasks/cloud_vpn/provisioners/aws_vpc/initiator/get_facts.yaml
@@ -2,8 +2,8 @@
 
 - name: Get initiator cloudformation VPC stack facts
   cloudformation_facts:
-    aws_access_key: "{{ cloud_vpn_initiator_aws_access_key  }}"
-    aws_secret_key: "{{ cloud_vpn_initiator_aws_secret_key  }}"
+    aws_access_key: "{{ cloud_vpn_initiator_aws_access_key | default(omit) }}"
+    aws_secret_key: "{{ cloud_vpn_initiator_aws_secret_key | default(omit) }}"
     security_token: "{{ cloud_vpn_initiator_aws_security_token | default(omit) }}"
     region: "{{ cloud_vpn_initiator_aws_region }}"
     stack_name: "{{ cloud_vpn_name }}-initiator-vpc-stack"

--- a/tasks/cloud_vpn/provisioners/aws_vpc/initiator/provision.yaml
+++ b/tasks/cloud_vpn/provisioners/aws_vpc/initiator/provision.yaml
@@ -2,8 +2,8 @@
 
 - name: Create initiator cloudformation VPC stack
   cloudformation:
-    aws_access_key: "{{ cloud_vpn_initiator_aws_access_key  }}"
-    aws_secret_key: "{{ cloud_vpn_initiator_aws_secret_key  }}"
+    aws_access_key: "{{ cloud_vpn_initiator_aws_access_key | default(omit) }}"
+    aws_secret_key: "{{ cloud_vpn_initiator_aws_secret_key | default(omit) }}"
     security_token: "{{ cloud_vpn_initiator_aws_security_token | default(omit) }}"
     region: "{{ cloud_vpn_initiator_aws_region }}"
     stack_name: "{{ cloud_vpn_name }}-initiator-vpc-stack"
@@ -11,8 +11,8 @@
 
 - name: Get VPC facts
   ec2_vpc_net_facts:
-    aws_access_key: "{{ cloud_vpn_initiator_aws_access_key }}"
-    aws_secret_key: "{{ cloud_vpn_initiator_aws_secret_key }}"
+    aws_access_key: "{{ cloud_vpn_initiator_aws_access_key | default(omit) }}"
+    aws_secret_key: "{{ cloud_vpn_initiator_aws_secret_key | default(omit) }}"
     security_token: "{{ cloud_vpn_initiator_aws_security_token | default(omit) }}"
     region: "{{ cloud_vpn_initiator_aws_region }}"
     filters:
@@ -25,8 +25,8 @@
 
 - name: Get route table facts
   ec2_vpc_route_table_facts:
-    aws_access_key: "{{ cloud_vpn_initiator_aws_access_key }}"
-    aws_secret_key: "{{ cloud_vpn_initiator_aws_secret_key }}"
+    aws_access_key: "{{ cloud_vpn_initiator_aws_access_key | default(omit) }}"
+    aws_secret_key: "{{ cloud_vpn_initiator_aws_secret_key | default(omit) }}"
     security_token: "{{ cloud_vpn_initiator_aws_security_token | default(omit) }}"
     region: "{{ cloud_vpn_initiator_aws_region }}"
     filters:
@@ -39,8 +39,8 @@
 
 - name: Get subnet facts
   ec2_vpc_subnet_facts:
-    aws_access_key: "{{ cloud_vpn_initiator_aws_access_key }}"
-    aws_secret_key: "{{ cloud_vpn_initiator_aws_secret_key }}"
+    aws_access_key: "{{ cloud_vpn_initiator_aws_access_key | default(omit) }}"
+    aws_secret_key: "{{ cloud_vpn_initiator_aws_secret_key | default(omit) }}"
     security_token: "{{ cloud_vpn_initiator_aws_security_token | default(omit) }}"
     region: "{{ cloud_vpn_initiator_aws_region }}"
     filters:

--- a/tasks/cloud_vpn/provisioners/aws_vpc/responder/deprovision.yaml
+++ b/tasks/cloud_vpn/provisioners/aws_vpc/responder/deprovision.yaml
@@ -1,8 +1,9 @@
 ---
 - name: Delete responder cloudformation VPC stack
+  run_once: true
   cloudformation:
-    aws_access_key: "{{ cloud_vpn_responder_aws_access_key  }}"
-    aws_secret_key: "{{ cloud_vpn_responder_aws_secret_key  }}"
+    aws_access_key: "{{ cloud_vpn_responder_aws_access_key | default(omit) }}"
+    aws_secret_key: "{{ cloud_vpn_responder_aws_secret_key | default(omit) }}"
     security_token: "{{ cloud_vpn_responder_aws_security_token | default(omit) }}"
     region: "{{ cloud_vpn_responder_aws_region }}"
     stack_name: "{{ cloud_vpn_name }}-responder-vpc-stack"

--- a/tasks/cloud_vpn/provisioners/aws_vpc/responder/get_facts.yaml
+++ b/tasks/cloud_vpn/provisioners/aws_vpc/responder/get_facts.yaml
@@ -2,8 +2,8 @@
 
 - name: Get responder cloudformation VPC stack facts
   cloudformation_facts:
-    aws_access_key: "{{ cloud_vpn_responder_aws_access_key  }}"
-    aws_secret_key: "{{ cloud_vpn_responder_aws_secret_key  }}"
+    aws_access_key: "{{ cloud_vpn_responder_aws_access_key | default(omit) }}"
+    aws_secret_key: "{{ cloud_vpn_responder_aws_secret_key | default(omit) }}"
     security_token: "{{ cloud_vpn_responder_aws_security_token | default(omit) }}"
     region: "{{ cloud_vpn_responder_aws_region }}"
     stack_name: "{{ cloud_vpn_name }}-responder-vpc-stack"

--- a/tasks/cloud_vpn/provisioners/aws_vpc/responder/provision.yaml
+++ b/tasks/cloud_vpn/provisioners/aws_vpc/responder/provision.yaml
@@ -1,9 +1,10 @@
 ---
 
 - name: Create responder cloudformation VPC stack
+  run_once: true
   cloudformation:
-    aws_access_key: "{{ cloud_vpn_responder_aws_access_key  }}"
-    aws_secret_key: "{{ cloud_vpn_responder_aws_secret_key  }}"
+    aws_access_key: "{{ cloud_vpn_responder_aws_access_key | default(omit) }}"
+    aws_secret_key: "{{ cloud_vpn_responder_aws_secret_key | default(omit) }}"
     security_token: "{{ cloud_vpn_responder_aws_security_token | default(omit) }}"
     region: "{{ cloud_vpn_responder_aws_region }}"
     stack_name: "{{ cloud_vpn_name }}-responder-vpc-stack"
@@ -11,8 +12,8 @@
 
 - name: Get VPC facts
   ec2_vpc_net_facts:
-    aws_access_key: "{{ cloud_vpn_responder_aws_access_key }}"
-    aws_secret_key: "{{ cloud_vpn_responder_aws_secret_key }}"
+    aws_access_key: "{{ cloud_vpn_responder_aws_access_key | default(omit) }}"
+    aws_secret_key: "{{ cloud_vpn_responder_aws_secret_key | default(omit) }}"
     security_token: "{{ cloud_vpn_responder_aws_security_token | default(omit) }}"
     region: "{{ cloud_vpn_responder_aws_region }}"
     filters:
@@ -25,8 +26,8 @@
 
 - name: Get route table facts
   ec2_vpc_route_table_facts:
-    aws_access_key: "{{ cloud_vpn_responder_aws_access_key }}"
-    aws_secret_key: "{{ cloud_vpn_responder_aws_secret_key }}"
+    aws_access_key: "{{ cloud_vpn_responder_aws_access_key | default(omit) }}"
+    aws_secret_key: "{{ cloud_vpn_responder_aws_secret_key | default(omit) }}"
     security_token: "{{ cloud_vpn_responder_aws_security_token | default(omit) }}"
     region: "{{ cloud_vpn_responder_aws_region }}"
     filters:
@@ -39,8 +40,8 @@
 
 - name: Get subnet facts
   ec2_vpc_subnet_facts:
-    aws_access_key: "{{ cloud_vpn_responder_aws_access_key }}"
-    aws_secret_key: "{{ cloud_vpn_responder_aws_secret_key }}"
+    aws_access_key: "{{ cloud_vpn_responder_aws_access_key | default(omit) }}"
+    aws_secret_key: "{{ cloud_vpn_responder_aws_secret_key | default(omit) }}"
     security_token: "{{ cloud_vpn_responder_aws_security_token | default(omit) }}"
     region: "{{ cloud_vpn_responder_aws_region }}"
     filters:

--- a/templates/cloud_vpn/provisioners/aws_igw/initiator/provision.j2
+++ b/templates/cloud_vpn/provisioners/aws_igw/initiator/provision.j2
@@ -5,7 +5,7 @@ Resources:
     Properties:
       Tags:
         - Key: Name
-          Value: {{ cloud_vpn_name }}-initiator-internetgw
+          Value: {{ cloud_vpn_initiator_internetgateway_name }}
   vpcgwattachment:
     Type: AWS::EC2::VPCGatewayAttachment
     Properties:

--- a/templates/cloud_vpn/provisioners/aws_igw/responder/provision.j2
+++ b/templates/cloud_vpn/provisioners/aws_igw/responder/provision.j2
@@ -5,7 +5,7 @@ Resources:
     Properties:
       Tags:
         - Key: Name
-          Value: {{ cloud_vpn_name }}-responder-internetgw
+          Value: {{ cloud_vpn_responder_internetgateway_name }}
   vpcgwattachment:
     Type: AWS::EC2::VPCGatewayAttachment
     Properties:

--- a/templates/cloud_vpn/provisioners/aws_instance/initiator/provision.j2
+++ b/templates/cloud_vpn/provisioners/aws_instance/initiator/provision.j2
@@ -3,7 +3,7 @@ Resources:
   securitygroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
-      GroupDescription: {{ cloud_vpn_name }}-initiator-securitygroup
+      GroupDescription: {{ cloud_vpn_initiator_securitygroup_name }}
       VpcId: {{ cloud_vpn_initiator_vpc_id }}
       SecurityGroupIngress:
         - IpProtocol: tcp
@@ -33,4 +33,4 @@ Resources:
           SubnetId: {{ cloud_vpn_initiator_subnet_id }}
       Tags:
         - Key: Name
-          Value: {{ cloud_vpn_name }}-initiator-instance
+          Value: {{ cloud_vpn_initiator_instance_name }}

--- a/templates/cloud_vpn/provisioners/aws_instance/responder/provision.j2
+++ b/templates/cloud_vpn/provisioners/aws_instance/responder/provision.j2
@@ -3,7 +3,7 @@ Resources:
   securitygroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
-      GroupDescription: {{ cloud_vpn_name }}-responder-securitygroup
+      GroupDescription: {{ cloud_vpn_responder_securitygroup_name }}
       VpcId: {{ cloud_vpn_responder_vpc_id }}
       SecurityGroupIngress:
         - IpProtocol: tcp
@@ -33,4 +33,4 @@ Resources:
           SubnetId: {{ cloud_vpn_responder_subnet_id }}
       Tags:
         - Key: Name
-          Value: {{ cloud_vpn_name }}-responder-instance
+          Value: {{ cloud_vpn_responder_instance_name }}

--- a/templates/cloud_vpn/provisioners/aws_vpc/initiator/provision.j2
+++ b/templates/cloud_vpn/provisioners/aws_vpc/initiator/provision.j2
@@ -6,7 +6,7 @@ Resources:
       CidrBlock: {{ cloud_vpn_initiator_vpc_cidr }}
       Tags:
         - Key: Name
-          Value: {{ cloud_vpn_name }}-initiator-vpc
+          Value: {{ cloud_vpn_initiator_vpc_name }}
   subnet:
     Type: AWS::EC2::Subnet
     Properties:
@@ -15,7 +15,7 @@ Resources:
       CidrBlock: {{ cloud_vpn_initiator_cidr }}
       Tags:
         - Key: Name
-          Value: {{ cloud_vpn_name }}-initiator-subnet
+          Value: {{ cloud_vpn_initiator_subnet_name }}
   routetable:
     Type: AWS::EC2::RouteTable
     Properties:
@@ -23,7 +23,7 @@ Resources:
         Ref: vpc
       Tags:
         - Key: Name
-          Value: {{ cloud_vpn_name }}-initiator-routetable
+          Value: {{ cloud_vpn_initiator_routetable_name }}
   subnetroutetableassociation:
     Type: AWS::EC2::SubnetRouteTableAssociation
     Properties:

--- a/templates/cloud_vpn/provisioners/aws_vpc/responder/provision.j2
+++ b/templates/cloud_vpn/provisioners/aws_vpc/responder/provision.j2
@@ -6,7 +6,7 @@ Resources:
       CidrBlock: {{ cloud_vpn_responder_vpc_cidr }}
       Tags:
         - Key: Name
-          Value: {{ cloud_vpn_name }}-responder-vpc
+          Value: {{ cloud_vpn_responder_vpc_name }}
   subnet:
     Type: AWS::EC2::Subnet
     Properties:
@@ -15,7 +15,7 @@ Resources:
       CidrBlock: {{ cloud_vpn_responder_cidr }}
       Tags:
         - Key: Name
-          Value: {{ cloud_vpn_name }}-responder-subnet
+          Value: {{ cloud_vpn_responder_subnet_name }}
   routetable:
     Type: AWS::EC2::RouteTable
     Properties:
@@ -23,7 +23,7 @@ Resources:
         Ref: vpc
       Tags:
         - Key: Name
-          Value: {{ cloud_vpn_name }}-responder-routetable
+          Value: {{ cloud_vpn_responder_routetable_name }}
   subnetroutetableassociation:
     Type: AWS::EC2::SubnetRouteTableAssociation
     Properties:


### PR DESCRIPTION
- access key may be injected as environment variable
- run_once to avoid race conditions when running in parallel
- default omit for access keys
- instance name based on role context variable.
- security group name based on role context variable.
- custom name for cloud resources
